### PR TITLE
Fix thread reply box hidden on mobile

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -312,9 +312,12 @@
   main {
     flex: 1;
     overflow-y: auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
   }
 
-  .feed { display: flex; flex-direction: column; }
+  .feed { display: flex; flex-direction: column; flex: 1; }
 
   .thread-card {
     border: none;
@@ -352,7 +355,8 @@
   .thread-view {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
+    min-height: 0;
   }
 
   .back {


### PR DESCRIPTION
## Summary
- Replaced fixed `100vh` height on `.thread-view` with flex-based layout
- `main` now uses `display: flex; flex-direction: column` so thread view fills remaining space
- Reply composer stays pinned at the bottom on mobile when sidebar stacks above

## Test plan
- [ ] Open a thread on mobile — reply box visible without scrolling
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)