### PR TITLE
Replace lucide-svelte with inline SVGs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,18 @@ The DNS record is a CNAME pointing to `<tunnel-id>.cfargotunnel.com` — home IP
 
 Trunk-based: short-lived feature branches merged to `main` via PR. `main` is always the stable state.
 
+**Every code change must start on a new branch — never commit directly to `main`.** Before touching any file, create a branch. Branch names follow the pattern `type/short-title`, where type is one of `feature`, `fix`, `refactor`, or `chore`. The title should be concise and reflect what is being changed (e.g. `feature/icons`, `fix/mobile-overflow`, `refactor/feed-layout`). When in doubt about the right name, use the gist of the user's request to derive it.
+
+## Code comments
+
+All code, especially backend code, should be commented at two levels:
+
+1. **Plain-English summaries on key sections** — written so that a non-technical person can follow what the code is doing and why. These sit above meaningful blocks (a function, a query, a data transformation) and describe the intent in simple terms, not implementation details. Example: *"Look up this thread in the database and reset its expiry timer, since someone just replied to it."*
+
+2. **Standard inline comments** — the usual good-practice notes explaining non-obvious logic, edge cases, magic numbers, or anything a programmer would need to maintain the code safely.
+
+When adding new code or modifying existing code, both levels should be present where appropriate.
+
 ## Planned features
 
 - User-controlled location noise (expose sigma via UI slider → send to backend)

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -131,8 +131,8 @@
       ></textarea>
       <div class="compose-footer">
         <span class="hint">⌘↵ to post</span>
-        <button on:click={submit} disabled={!draft.trim() || posting || !location}>
-          {posting ? '…' : 'post'}
+        <button on:click={submit} disabled={!draft.trim() || posting || !location} aria-label="post">
+          {#if posting}…{:else}<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>{/if}
         </button>
       </div>
     </div>
@@ -148,7 +148,9 @@
   <main>
     {#if activeThread}
       <div class="thread-view">
-        <button class="back" on:click={() => { activeThread = null; comments = []; }}>← back</button>
+        <button class="back" on:click={() => { activeThread = null; comments = []; }} aria-label="back">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+        </button>
         <div class="thread-op">
           <p>{activeThread.content}</p>
           <span class="meta">{timeAgo(activeThread.created_at)} · expires in {expiresIn(activeThread)}</span>
@@ -172,8 +174,8 @@
             on:keydown={handleCommentKey}
             maxlength="500"
           ></textarea>
-          <button on:click={submitComment} disabled={!commentDraft.trim() || posting}>
-            {posting ? '…' : 'reply'}
+          <button on:click={submitComment} disabled={!commentDraft.trim() || posting} aria-label="reply">
+            {#if posting}…{:else}<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 10 4 15 9 20"/><path d="M20 4v7a4 4 0 0 1-4 4H4"/></svg>{/if}
           </button>
         </div>
       </div>
@@ -298,11 +300,14 @@
     background: none;
     border: 1px solid #333;
     color: #e0e0e0;
-    padding: 6px 14px;
+    padding: 6px 10px;
     font-family: inherit;
     font-size: 13px;
     cursor: pointer;
     text-transform: lowercase;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   button:hover:not(:disabled) { border-color: #888; }


### PR DESCRIPTION
## Summary
- Swap out the broken `lucide-svelte` package for three hand-rolled inline SVGs
- Icons: `→` (post), `↵` (reply), `←` (back) — matching the original unicode intent
- Uninstall `lucide-svelte` entirely, no external icon dependency
- Add branching and code comment conventions to CLAUDE.md

## Test plan
- [ ] App loads without black screen
- [ ] Post button shows `→` arrow
- [ ] Reply button shows `↵` arrow  
- [ ] Back button shows `←` arrow
- [ ] All three icons visible on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)