### PR TITLE
Switch to Outfit font and fix message alignment

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500&display=swap" rel="stylesheet" />
     %sveltekit.head%
   </head>
   <body>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -205,8 +205,8 @@
   :global(body) {
     background: #0a0a0a;
     color: #e0e0e0;
-    font-family: 'Courier New', monospace;
-    font-size: 14px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 22px;
     min-height: 100vh;
   }
 
@@ -322,10 +322,9 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
   }
 
-  .feed { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .feed { display: flex; flex-direction: column; flex: 1; }
 
   .thread-card {
     border: none;
@@ -336,6 +335,8 @@
     cursor: pointer;
     display: flex;
     flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
     gap: 8px;
     background: none;
     color: inherit;
@@ -367,7 +368,6 @@
     min-height: 0;
     overflow-y: auto;
     width: 100%;
-    align-items: flex-start;
   }
 
   .back {


### PR DESCRIPTION
## Summary
- Messages were horizontally centered due to `justify-content: center` on the global button style leaking into thread cards — fixed with explicit `flex-start` on `.thread-card`
- Removed incorrect `align-items: flex-start` on `main` and `thread-view` which caused children to shrink instead of stretch
- Switched font to Outfit (Google Fonts) at 22px

🤖 Generated with [Claude Code](https://claude.com/claude-code)