### PR TITLE
Set DM Mono as app font at 22px

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ When adding new code or modifying existing code, both levels should be present w
 
 ## Planned features
 
+- Typography: reconsider font choice — current is DM Mono (monospace, fits the anonymous/terminal feel). Outfit was a strong proportional candidate worth revisiting if the app's personality shifts toward something warmer or more accessible.
+
 - User-controlled location noise (expose sigma via UI slider → send to backend)
 - Live expiry countdown that ticks in real time
 - `thread_expired` WebSocket event to remove dead threads from feed automatically

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -7,7 +7,7 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet" />
     %sveltekit.head%
   </head>
   <body>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -205,7 +205,7 @@
   :global(body) {
     background: #0a0a0a;
     color: #e0e0e0;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'DM Mono', monospace;
     font-size: 22px;
     min-height: 100vh;
   }


### PR DESCRIPTION
## Summary
- DM Mono at 22px chosen over Outfit and Nunito
- Keeps the anonymous/terminal character of the app
- Outfit noted in CLAUDE.md planned features as a candidate to revisit

🤖 Generated with [Claude Code](https://claude.com/claude-code)