### PR TITLE
Fade thread cards as they approach expiry

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,6 +13,9 @@
   let comments = [];
   let posting = false;
   let locationError = null;
+  // Ticks every 10s so expiry-based opacity updates live on screen
+  let now = Date.now();
+  let ticker;
 
   onMount(async () => {
     if (!navigator.geolocation) {
@@ -36,7 +39,8 @@
     );
   });
 
-  onDestroy(() => ws?.close());
+  onMount(() => { ticker = setInterval(() => { now = Date.now(); }, 10000); });
+  onDestroy(() => { ws?.close(); clearInterval(ticker); });
 
   function handleWsEvent(event) {
     if (event.type === 'new_thread') {
@@ -99,6 +103,18 @@
     const m = Math.floor(remaining / 60);
     const s = remaining % 60;
     return m > 0 ? `${m}m` : `${s}s`;
+  }
+
+  // Returns opacity for a thread card based on how close it is to expiring.
+  // Full opacity above 10 minutes remaining, fades linearly down to 0.3 at death.
+  // Uses `now` so Svelte re-evaluates this reactively every 10 seconds.
+  function threadOpacity(thread) {
+    void now; // reactive dependency
+    const remaining = thread.expires_at - Math.floor(Date.now() / 1000);
+    if (remaining <= 0) return 0.3;
+    const fadeStart = 600; // begin fading at 10 minutes
+    if (remaining >= fadeStart) return 1;
+    return 0.3 + (remaining / fadeStart) * 0.7;
   }
 
   function handleKey(e) {
@@ -189,7 +205,7 @@
     {:else}
       <div class="feed">
         {#each threads as t (t.id)}
-          <button class="thread-card" on:click={() => openThread(t)}>
+          <button class="thread-card" on:click={() => openThread(t)} style="opacity: {threadOpacity(t)};">
             <p class="thread-content">{t.content}</p>
             <div class="thread-meta">
               <span>{t.comment_count} {t.comment_count === 1 ? 'reply' : 'replies'}</span>


### PR DESCRIPTION
## Summary
- Thread cards fade from full opacity to 0.3 over the last 10 minutes of their life
- A reactive `now` ticker (10s interval) keeps the fade live on screen
- Gives users a passive visual signal that a thread is dying without any text clutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)