### PR TITLE
Add session log convention (local only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ backend/dump.rdb
 
 # OS
 .DS_Store
+
+# Local session log — not for version control
+HLV-LOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Session log
+
+A running local log is kept in `HLV-LOG.md` (gitignored — never committed). At the end of each session, append a new entry summarising what was achieved, any open issues, and anything worth knowing before the next session. At the start of each session, read `HLV-LOG.md` and present a short recap to the user before doing anything else.
+
 ## What this is
 
 **hlv** — anonymous, ephemeral, location-based messaging. No accounts, no history. Open it, post a message, see what people nearby are saying. Threads die if ignored.


### PR DESCRIPTION
## Summary
- HLV-LOG.md added to .gitignore — stays local, never pushed
- CLAUDE.md documents the convention: append summary at end of session, recap at start of next

🤖 Generated with [Claude Code](https://claude.com/claude-code)