### PR TITLE
Wire up noise slider to backend sigma

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -26,6 +26,9 @@ pub struct CreateThread {
     pub content: String,
     pub lat: f64,
     pub lng: f64,
+    // How much Gaussian noise to apply to the post location, in metres.
+    // Optional — defaults to 300m on the backend if not provided.
+    pub noise_sigma: Option<f64>,
 }
 
 // POST /threads/:id/comments

--- a/backend/src/routes/threads.rs
+++ b/backend/src/routes/threads.rs
@@ -26,8 +26,12 @@ pub async fn post_thread(
         .unwrap()
         .as_secs() as i64;
 
-    let (fuzzed_lat, fuzzed_lng) =
-        fuzz_coordinates(body.lat, body.lng, DEFAULT_NOISE_SIGMA_METERS);
+    // Use the client-supplied sigma if provided, otherwise fall back to the default.
+    // Clamped to 0–1000m so the client can't request absurd noise levels.
+    let sigma = body.noise_sigma
+        .unwrap_or(DEFAULT_NOISE_SIGMA_METERS)
+        .clamp(0.0, 1000.0);
+    let (fuzzed_lat, fuzzed_lng) = fuzz_coordinates(body.lat, body.lng, sigma);
 
     let thread = Thread {
         id: Uuid::new_v4().to_string(),

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,8 +1,8 @@
-export async function postThread(content, lat, lng) {
+export async function postThread(content, lat, lng, noise_sigma) {
   const res = await fetch('/api/threads', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content, lat, lng })
+    body: JSON.stringify({ content, lat, lng, noise_sigma })
   });
   if (!res.ok) throw new Error('Failed to post');
   return res.json();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -57,7 +57,7 @@
     if (!draft.trim() || !location || posting) return;
     posting = true;
     try {
-      await postThread(draft.trim(), location.lat, location.lng);
+      await postThread(draft.trim(), location.lat, location.lng, noise);
       draft = '';
     } finally {
       posting = false;
@@ -115,8 +115,7 @@
 
       <label class="noise-label">
         <span>noise <strong>{noise}m</strong></span>
-        <input type="range" min="50" max="1000" step="50" bind:value={noise} disabled />
-        <small>location fuzzing — coming soon</small>
+        <input type="range" min="50" max="1000" step="50" bind:value={noise} />
       </label>
     </div>
 
@@ -253,14 +252,6 @@
     width: 100%;
     accent-color: #e0e0e0;
     cursor: pointer;
-  }
-
-  input[type="range"]:disabled { opacity: 0.3; cursor: not-allowed; }
-
-  .noise-label small {
-    font-size: 11px;
-    color: #444;
-    font-style: italic;
   }
 
   .compose {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -93,6 +93,38 @@
     return `${Math.floor(diff / 3600)}h`;
   }
 
+  // --- Location preview ---
+  // Mirrors the two-layer fuzzing the backend applies at post time
+  // (grid snap + Gaussian jitter), so the user can see roughly where
+  // their message will appear — not their exact location.
+
+  const GRID_METERS = 100;
+  const METERS_PER_DEG_LAT = 111_320;
+
+  // Box-Muller transform: converts two uniform random numbers into one
+  // Gaussian-distributed value with mean 0 and standard deviation 1.
+  function gaussianRandom() {
+    let u, v;
+    do { u = Math.random(); } while (u === 0);
+    do { v = Math.random(); } while (v === 0);
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+  }
+
+  // Replicate the backend fuzz: snap to ~100m grid, then add Gaussian jitter.
+  // Returns [lat, lng] of the approximate posted location.
+  function computeFuzzPreview(lat, lng, sigma) {
+    const gridLat = GRID_METERS / METERS_PER_DEG_LAT;
+    const gridLng = GRID_METERS / (METERS_PER_DEG_LAT * Math.cos(lat * Math.PI / 180));
+    const snappedLat = Math.round(lat / gridLat) * gridLat;
+    const snappedLng = Math.round(lng / gridLng) * gridLng;
+    const jitterLat = gaussianRandom() * sigma / METERS_PER_DEG_LAT;
+    const jitterLng = gaussianRandom() * sigma / (METERS_PER_DEG_LAT * Math.cos(snappedLat * Math.PI / 180));
+    return [snappedLat + jitterLat, snappedLng + jitterLng];
+  }
+
+  // Recomputes whenever the noise slider or location changes, giving a live preview.
+  $: previewCoords = location ? computeFuzzPreview(location.lat, location.lng, noise) : null;
+
   function handleKey(e) {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) submit();
   }
@@ -116,6 +148,9 @@
       <label class="noise-label">
         <span>noise <strong>{noise}m</strong></span>
         <input type="range" min="50" max="1000" step="50" bind:value={noise} />
+        {#if previewCoords}
+          <small class="location-preview">publicado cerca de {previewCoords[0].toFixed(4)}, {previewCoords[1].toFixed(4)}</small>
+        {/if}
       </label>
     </div>
 
@@ -180,7 +215,7 @@
           <button class="thread-card" on:click={() => openThread(t)}>
             <p class="thread-content">{t.content}</p>
             <div class="thread-meta">
-              <span>{t.comment_count} {t.comment_count === 1 ? 'reply' : 'replies'}</span>
+              <span>{t.comment_count} {t.comment_count === 1 ? 'respuesta' : 'respuestas'}</span>
               <span>{timeAgo(t.created_at)}</span>
             </div>
           </button>
@@ -252,6 +287,13 @@
     width: 100%;
     accent-color: #e0e0e0;
     cursor: pointer;
+  }
+
+  .location-preview {
+    font-size: 11px;
+    color: #444;
+    font-style: italic;
+    line-height: 1.4;
   }
 
   .compose {


### PR DESCRIPTION
## Summary
- Adds optional `noise_sigma` field to `POST /threads` — backend clamps to 0–1000m, defaults to 300m if omitted
- Enables the noise slider in the UI; threads are now fuzzed by the user's chosen level
- Shows a live **'publicado cerca de lat, lng'** preview below the slider, computed client-side using the same grid-snap + Gaussian algorithm as the backend
- Translates reply count to Spanish (respuesta/respuestas)

## Test plan
- [ ] Drag the noise slider — coordinates in the preview should shift on each move
- [ ] Post at min noise (50m) — thread appears close to actual location
- [ ] Post at max noise (1000m) — thread appears noticeably offset
- [ ] Confirm reply count shows "respuesta" (singular) and "respuestas" (plural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)