### PR TITLE
Move reply box below comments list

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -188,6 +188,14 @@
           <p>{activeThread.content}</p>
           <span class="meta">{timeAgo(activeThread.created_at)}</span>
         </div>
+        <div class="comment-list">
+          {#each comments as c}
+            <div class="comment">
+              <p>{c.content}</p>
+              <span class="meta">{timeAgo(c.created_at)}</span>
+            </div>
+          {/each}
+        </div>
         <div class="comment-compose">
           <textarea
             bind:value={commentDraft}
@@ -199,14 +207,6 @@
           <button on:click={submitComment} disabled={!commentDraft.trim() || posting} aria-label="reply">
             {#if posting}…{:else}<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 10 4 15 9 20"/><path d="M20 2v9a4 4 0 0 1-4 4H2"/></svg>{/if}
           </button>
-        </div>
-        <div class="comment-list">
-          {#each comments as c}
-            <div class="comment">
-              <p>{c.content}</p>
-              <span class="meta">{timeAgo(c.created_at)}</span>
-            </div>
-          {/each}
         </div>
       </div>
     {:else}
@@ -450,7 +450,6 @@
 
   .comment-compose {
     border-top: 1px solid #1e1e1e;
-    border-bottom: 1px solid #1e1e1e;
     padding: 12px 24px;
     display: flex;
     gap: 8px;


### PR DESCRIPTION
## Summary
Moves the reply compose box to below the last comment instead of between the original post and replies. On a thread with no replies it still appears directly under the OP. Also removes the now-redundant `border-bottom` on `.comment-compose`.

## Test plan
- [ ] Open a thread with no replies — reply box appears directly under the OP
- [ ] Open a thread with replies — reply box appears below the last comment
- [ ] Posting a reply still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)