### PR TITLE
Indent comments with left border for thread hierarchy

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -439,8 +439,9 @@
   }
 
   .comment {
-    padding: 12px 24px;
+    padding: 12px 24px 12px 40px;
     border-bottom: 1px solid #141414;
+    border-left: 2px solid #1e1e1e;
     display: flex;
     flex-direction: column;
     gap: 4px;


### PR DESCRIPTION
## Summary
Adds `padding-left: 40px` and a faint `border-left: 2px solid #1e1e1e` to reply cards, visually separating them from the original post and reinforcing the thread structure.

## Test plan
- [ ] Open a thread with replies — comments appear indented with a subtle left border
- [ ] Original post remains unindented

🤖 Generated with [Claude Code](https://claude.com/claude-code)