### PR TITLE
Railway deployment: Dockerfile, railway.toml, and VITE_API_BASE wiring

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# ---- Build stage ----
+# Use the official Rust image to compile a release binary.
+FROM rust:1.85-slim AS builder
+
+WORKDIR /app
+
+# Copy only the backend source (build context is the repo root).
+COPY backend/ .
+
+RUN cargo build --release
+
+# ---- Runtime stage ----
+# Minimal Debian image — no Rust toolchain, just the binary and TLS certs.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/hlv /usr/local/bin/hlv
+
+CMD ["hlv"]

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,5 +1,26 @@
+// In dev, VITE_API_BASE is unset and Vite proxies /api/* → localhost:3000.
+// In production, VITE_API_BASE = "https://backend-production-fa211.up.railway.app"
+// and we call the backend directly (no /api prefix needed).
+const API_BASE = import.meta.env.VITE_API_BASE ?? '';
+
+// Build a full URL for HTTP endpoints.
+// Dev:  url('/threads') → '/api/threads'  (Vite proxy strips /api)
+// Prod: url('/threads') → 'https://backend.../threads'
+function url(path) {
+  return API_BASE ? `${API_BASE}${path}` : `/api${path}`;
+}
+
+// Build the WebSocket URL, deriving wss:// from the API base when set.
+function wsUrl() {
+  if (API_BASE) {
+    return `${API_BASE.replace(/^https/, 'wss').replace(/^http/, 'ws')}/ws`;
+  }
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${location.host}/ws`;
+}
+
 export async function postThread(content, lat, lng, noise_sigma) {
-  const res = await fetch('/api/threads', {
+  const res = await fetch(url('/threads'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content, lat, lng, noise_sigma })
@@ -9,13 +30,13 @@ export async function postThread(content, lat, lng, noise_sigma) {
 }
 
 export async function getFeed(lat, lng, radius_km) {
-  const res = await fetch(`/api/feed?lat=${lat}&lng=${lng}&radius_km=${radius_km}`);
+  const res = await fetch(url(`/feed?lat=${lat}&lng=${lng}&radius_km=${radius_km}`));
   if (!res.ok) throw new Error('Failed to fetch feed');
   return res.json();
 }
 
 export async function postComment(threadId, content) {
-  const res = await fetch(`/api/threads/${threadId}/comments`, {
+  const res = await fetch(url(`/threads/${threadId}/comments`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content })
@@ -25,14 +46,13 @@ export async function postComment(threadId, content) {
 }
 
 export async function getComments(threadId) {
-  const res = await fetch(`/api/threads/${threadId}/comments`);
+  const res = await fetch(url(`/threads/${threadId}/comments`));
   if (!res.ok) throw new Error('Failed to fetch comments');
   return res.json();
 }
 
 export function connectWs(lat, lng, radius_km, onEvent) {
-  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const ws = new WebSocket(`${protocol}//${location.host}/ws`);
+  const ws = new WebSocket(wsUrl());
 
   ws.onopen = () => {
     ws.send(JSON.stringify({ lat, lng, radius_km }));

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,4 @@
+[build]
+# Build the Rust backend from the Dockerfile in the backend/ subdirectory.
+# The build context is the repo root so the Dockerfile can COPY backend/ correctly.
+dockerfilePath = "backend/Dockerfile"


### PR DESCRIPTION
## Summary
- Adds `backend/Dockerfile` (multi-stage Rust build) and `railway.toml` for Railway deployment
- Wires `VITE_API_BASE` in `frontend/src/lib/api.js` so production calls the Railway backend directly; dev falls back to Vite proxy as before

## Test plan
- [ ] Backend responds at `https://backend-production-fa211.up.railway.app` (verified live)
- [ ] Frontend builds with `VITE_API_BASE` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)