### PR TITLE
Fix location retry button and blog font sizes

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   let comments = [];
   let posting = false;
   let locationError = null;
+  let retrying = false;
 
   // Incremented every 30s so that decay bar widths re-evaluate reactively.
   let tick = 0;
@@ -35,16 +36,32 @@
   // Asks the browser for the user's location and initialises the feed and
   // WebSocket connection once granted. Safe to call more than once — e.g.
   // when the user taps the retry button after an initial denial.
-  function requestLocation() {
+  async function requestLocation() {
     locationError = null;
+    retrying = true;
+
+    // If the browser has permanently blocked location (not just dismissed the
+    // prompt), getCurrentPosition would fire the error callback immediately
+    // with no visible prompt. Detect that early and show actionable copy instead.
+    if (navigator.permissions) {
+      const perm = await navigator.permissions.query({ name: 'geolocation' });
+      if (perm.state === 'denied') {
+        retrying = false;
+        locationError = 'El acceso a la ubicación está bloqueado en tu navegador. Para continuar, restablece el permiso de ubicación en la configuración del sitio e intenta de nuevo.';
+        return;
+      }
+    }
+
     navigator.geolocation.getCurrentPosition(
       async (pos) => {
+        retrying = false;
         location = { lat: pos.coords.latitude, lng: pos.coords.longitude };
         threads = await getFeed(location.lat, location.lng, radius);
         ws = connectWs(location.lat, location.lng, radius, handleWsEvent);
         tickInterval = setInterval(() => { tick++; }, 30_000);
       },
       () => {
+        retrying = false;
         locationError = 'Suena horrible, pero necesitamos que permitas que el servicio obtenga tu ubicación a través del navegador. Esta ubicación no será almacenada ni asociada a ti de ninguna forma.';
       }
     );
@@ -198,7 +215,9 @@
     {#if locationError}
       <div class="location-error">
         <p class="status error">{locationError}</p>
-        <button class="retry-btn" on:click={requestLocation}>intentar de nuevo</button>
+        <button class="retry-btn" on:click={requestLocation} disabled={retrying}>
+          {retrying ? '…' : 'intentar de nuevo'}
+        </button>
       </div>
     {:else if !location}
       <p class="status">waiting for location…</p>

--- a/frontend/src/routes/blog/+page.svelte
+++ b/frontend/src/routes/blog/+page.svelte
@@ -79,8 +79,8 @@
   .brand:hover { color: #aaa; }
 
   .tagline {
-    font-size: 11px;
-    color: #444;
+    font-size: 18px;
+    color: #888;
     letter-spacing: 2px;
     text-transform: lowercase;
   }
@@ -134,7 +134,7 @@
   .body p {
     line-height: 1.75;
     color: #ccc;
-    font-size: 16px;
+    font-size: 17px;
   }
 
   hr {


### PR DESCRIPTION
## Location retry button
- Added `retrying` state so the button shows `…` while waiting — gives visible feedback even when the browser responds instantly
- Used the Permissions API to detect a hard block (`state === 'denied'`) before calling `getCurrentPosition`. When blocked, shows actionable copy: *"restablece el permiso de ubicación en la configuración del sitio"* — previously the button would silently re-fire the error with no prompt

## Blog font sizes
- Tagline "hablan los vecinos": 11px → 18px, color #444 → #888 (now clearly bigger than body text)
- Body text: 16px → 17px

🤖 Generated with [Claude Code](https://claude.com/claude-code)