### PR TITLE
Translate empty feed message to Spanish

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -270,7 +270,7 @@
           </button>
         {/each}
         {#if threads.length === 0 && location}
-          <p class="empty">nothing nearby. be the first.</p>
+          <p class="empty">nada por aquí. sé el primero.</p>
         {/if}
       </div>
     {/if}


### PR DESCRIPTION
"nothing nearby. be the first." → "nada por aquí. sé el primero."

🤖 Generated with [Claude Code](https://claude.com/claude-code)