### PR TITLE
Push thread_expired WS event; auto-remove stale threads from feed

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,6 +35,31 @@ async fn main() {
         clients: Arc::new(RwLock::new(HashMap::new())),
     };
 
+    // Background task: every 30 seconds, scan the geo index for thread keys
+    // that Redis has expired, clean them up, and push thread_expired events
+    // so connected clients remove stale threads without needing a refresh.
+    let sweep_state = state.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            let mut con = sweep_state.redis.clone();
+            match store::sweep_expired_threads(&mut con).await {
+                Ok(expired) => {
+                    for thread_id in expired {
+                        ws::broadcast_all(
+                            &sweep_state.clients,
+                            ws::WsEvent::ThreadExpired { thread_id },
+                        )
+                        .await;
+                    }
+                }
+                Err(e) => tracing::warn!("sweep_expired_threads error: {e}"),
+            }
+        }
+    });
+
     let app = Router::new()
         .route("/threads", post(routes::threads::post_thread))
         .route("/feed", get(routes::threads::get_feed_handler))

--- a/backend/src/store.rs
+++ b/backend/src/store.rs
@@ -153,6 +153,28 @@ pub async fn get_feed(
     Ok(threads)
 }
 
+/// Scans the geo index for thread IDs whose Redis key has already expired,
+/// removes them from the index, and returns the list of expired IDs so the
+/// caller can broadcast a thread_expired event to connected clients.
+pub async fn sweep_expired_threads(
+    con: &mut ConnectionManager,
+) -> redis::RedisResult<Vec<String>> {
+    // Get every member currently in the geo index (the set never auto-expires).
+    let ids: Vec<String> = con.zrange(GEO_KEY, 0isize, -1isize).await?;
+
+    let mut expired = Vec::new();
+    for id in ids {
+        let key = format!("thread:{id}");
+        let exists: bool = con.exists(&key).await?;
+        if !exists {
+            // Thread key is gone — remove the stale geo entry and note the ID.
+            let _: () = con.zrem(GEO_KEY, &id).await?;
+            expired.push(id);
+        }
+    }
+    Ok(expired)
+}
+
 fn parse_thread_fields(fields: &[String]) -> Option<Thread> {
     let mut map = std::collections::HashMap::new();
     let mut iter = fields.iter();

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -27,6 +27,9 @@ pub type ClientMap = Arc<RwLock<HashMap<Uuid, WsClient>>>;
 pub enum WsEvent {
     NewThread { data: serde_json::Value },
     NewComment { thread_id: String, data: serde_json::Value },
+    // Sent when a thread's Redis key expires so clients can remove it from
+    // their feed without waiting for a refresh.
+    ThreadExpired { thread_id: String },
 }
 
 /// Inbound message from client to register/update location.
@@ -48,6 +51,20 @@ pub async fn broadcast(clients: &ClientMap, thread_lat: f64, thread_lng: f64, ev
         if haversine_km(thread_lat, thread_lng, client.lat, client.lng) <= client.radius_km {
             let _ = client.tx.send(json.clone());
         }
+    }
+}
+
+/// Broadcast an event to every connected client regardless of location.
+/// Used for thread_expired: any client could have the thread in their feed,
+/// and a client that doesn't will simply no-op the filter on their end.
+pub async fn broadcast_all(clients: &ClientMap, event: WsEvent) {
+    let json = match serde_json::to_string(&event) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let map = clients.read().await;
+    for client in map.values() {
+        let _ = client.tx.send(json.clone());
     }
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -91,6 +91,14 @@
       if (activeThread?.id === event.thread_id) {
         comments = [...comments, event.data];
       }
+    } else if (event.type === 'thread_expired') {
+      // Remove the expired thread from the feed. If it's currently open,
+      // drop back to the feed — the thread is gone and there's nothing to show.
+      threads = threads.filter(t => t.id !== event.thread_id);
+      if (activeThread?.id === event.thread_id) {
+        activeThread = null;
+        comments = [];
+      }
     }
   }
 


### PR DESCRIPTION
## What this does
Threads now disappear from connected clients' feeds automatically when they expire, without requiring a refresh.

## Backend
- New `ThreadExpired { thread_id }` variant on `WsEvent`
- `sweep_expired_threads()` in `store.rs`: scans the geo index every 30s, finds thread IDs whose Redis key has expired, removes the stale geo entry, returns the IDs
- `broadcast_all()` in `ws.rs`: broadcasts to every connected client (no geo check needed — clients that don't have the thread simply no-op the filter)
- Background `tokio::spawn` in `main.rs` wires sweep → broadcast on a 30s interval with `MissedTickBehavior::Delay`

## Frontend
Handles `thread_expired` in `handleWsEvent`:
- Filters the thread from the feed array
- If the thread is currently open, closes it and returns to the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)