### PR TITLE
Fix production reload loop and soften blog tagline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ A running local log is kept in `HLV-LOG.md` (gitignored — never committed). At
 
 **hlv** — anonymous, ephemeral, location-based messaging. No accounts, no history. Open it, post a message, see what people nearby are saying. Threads die if ignored.
 
+## Deploying to production
+
+**Frontend** (Cloudflare Pages → `demo.bavardage.org`):
+```bash
+cd frontend
+VITE_API_BASE=https://backend-production-fa211.up.railway.app npm run build
+npx wrangler pages deploy build --project-name hlv --commit-dirty=true
+```
+Run this after merging to `main` whenever you want changes live.
+
+**Backend** (Railway) — deploys automatically on push to `main`. No manual step needed.
+
 ## Running locally
 
 Single command to start everything:
@@ -99,6 +111,16 @@ Vite proxies `/api/*` → `localhost:3000` and `/ws` → `ws://localhost:3000`, 
 Config lives at `~/.cloudflared/config.yml` (not in the repo). Tunnel name: `hlv`, ID: `8d5d283b-16d6-4fa1-9348-be4956d56074`. Routes `hlv.bavardage.org` → `http://127.0.0.1:5173`.
 
 The DNS record is a CNAME pointing to `<tunnel-id>.cfargotunnel.com` — home IP changes don't affect it.
+
+## Debugging and diagnosis
+
+Before trying a fix, map the problem space first. Touch a couple of plausible culprits — check evidence for each — before committing to a solution. One wrong guess wastes less time than six sequential wrong guesses.
+
+A useful starting sequence for any production issue:
+1. Confirm what's actually broken (HTTP status, response body, headers) — don't assume
+2. Identify the layers that could be responsible (code, CDN cache, DNS, infrastructure, deployment state)
+3. Spot where the layers diverge (e.g. preview URL works but custom domain doesn't → deployment is fine, routing/cache layer is the culprit)
+4. Then fix
 
 ## Branching
 

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet" />
+    <meta name="generator" content="hlv" />
     %sveltekit.head%
   </head>
   <body>

--- a/frontend/src/routes/+layout.js
+++ b/frontend/src/routes/+layout.js
@@ -1,2 +1,2 @@
-export const prerender = false;
+export const prerender = true;
 export const ssr = false;

--- a/frontend/src/routes/blog/+page.svelte
+++ b/frontend/src/routes/blog/+page.svelte
@@ -79,9 +79,9 @@
   .brand:hover { color: #aaa; }
 
   .tagline {
-    font-size: 18px;
-    color: #888;
-    letter-spacing: 2px;
+    font-size: 11px;
+    color: #444;
+    letter-spacing: 1px;
     text-transform: lowercase;
   }
 

--- a/frontend/static/_headers
+++ b/frontend/static/_headers
@@ -1,0 +1,5 @@
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+
+/_app/immutable/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Fixes infinite reload loop on `demo.bavardage.org` caused by SvelteKit version mismatch between stale cached `404.html` and updated `version.json`. Root fix: `prerender=true` in `+layout.js` so the build generates a real `index.html`, bypassing Cloudflare Pages' sticky fallback cache.
- Adds `static/_headers` so HTML files get `max-age=0, must-revalidate` — prevents the 7-day CDN caching of the SPA shell from recurring.
- Reverts blog tagline to `11px / #444` — matches the sidebar blog link styling, quiet and consistent.
- Adds a debugging-before-fixing guideline to `CLAUDE.md`.

## Test plan
- [ ] Visit `demo.bavardage.org` — no reload loop
- [ ] Visit `/blog` — tagline is small and dim, matches the sidebar link feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)