### PR TITLE
Lower message length limit to 300 chars

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -210,7 +210,7 @@
         placeholder="¿qué se dice?"
         rows="4"
         on:keydown={handleKey}
-        maxlength="500"
+        maxlength="300"
       ></textarea>
       <div class="compose-footer">
         <span class="hint">⌘↵ to post</span>
@@ -257,7 +257,7 @@
             placeholder="        ← respondo aquí"
             rows="2"
             on:keydown={handleCommentKey}
-            maxlength="500"
+            maxlength="300"
           ></textarea>
           <button on:click={submitComment} disabled={!commentDraft.trim() || posting} aria-label="reply">
             {#if posting}…{:else}<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 10 4 15 9 20"/><path d="M20 2v9a4 4 0 0 1-4 4H2"/></svg>{/if}


### PR DESCRIPTION
## Summary
- Drops `maxlength` on both the compose textarea and the reply textarea from 500 → 300. Keeps things tight; can revisit based on real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)