### PR TITLE
Cap radius slider at 10km

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ When adding new code or modifying existing code, both levels should be present w
 
 - Typography: reconsider font choice — current is DM Mono (monospace, fits the anonymous/terminal feel). Outfit was a strong proportional candidate worth revisiting if the app's personality shifts toward something warmer or more accessible.
 
+- Radius slider lower limit: consider dropping minimum from 1km → 0.5km for dense areas (0.5km steps). Tradeoff: the 300m Gaussian jitter means ~30% of posts from your immediate vicinity fall outside a 0.5km radius — users might see an empty feed in a crowded spot. Needs thought or a reduced sigma at small radii.
 - User-controlled location noise (expose sigma via UI slider → send to backend)
 - Live expiry countdown that ticks in real time
 - `thread_expired` WebSocket event to remove dead threads from feed automatically

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -113,7 +113,7 @@ async fn run_receiver(
         let Ok(msg) = result else { break };
         if let Message::Text(text) = msg {
             if let Ok(update) = serde_json::from_str::<LocationUpdate>(&text) {
-                let radius = update.radius_km.clamp(1.0, 20.0);
+                let radius = update.radius_km.clamp(1.0, 10.0);
                 if let Some(client) = clients.write().await.get_mut(&id) {
                     client.lat = update.lat;
                     client.lng = update.lng;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -192,7 +192,7 @@
     <div class="controls">
       <label>
         <span>radio <strong>{radius}km</strong></span>
-        <input type="range" min="1" max="20" step="1" bind:value={radius} on:change={onRadiusChange} />
+        <input type="range" min="1" max="10" step="1" bind:value={radius} on:change={onRadiusChange} />
       </label>
 
       <label class="noise-label">


### PR DESCRIPTION
## Summary
- Frontend slider: `max="20"` → `max="10"`
- Backend WS clamp: `clamp(1.0, 20.0)` → `clamp(1.0, 10.0)`
- Noted 0.5km lower limit idea in `CLAUDE.md` planned features

🤖 Generated with [Claude Code](https://claude.com/claude-code)