### PR TITLE
Add config layer: externalize all protocol parameters via env vars

### DIFF
--- a/API.md
+++ b/API.md
@@ -173,7 +173,7 @@ A compliant qhlv node exposes the following as environment variables or a config
 
 | Parameter | Default | Description |
 |---|---|---|
-| `INACTIVITY_TTL_SECS` | 900 | Seconds of silence before a thread expires |
+| `INACTIVITY_TTL_SECS` | 1800 | Seconds of silence before a thread expires |
 | `HARD_CAP_SECS` | 3600 | Maximum thread lifetime from creation |
 | `DEFAULT_SIGMA_M` | 300 | Default Gaussian jitter in metres |
 | `MAX_SIGMA_M` | 1000 | Upper bound on client-requested sigma |

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,0 +1,42 @@
+use std::env;
+
+/// Server-wide configuration loaded from environment variables at startup.
+/// Every field has a default so the server runs without any env setup.
+#[derive(Clone)]
+pub struct Config {
+    /// How long a thread stays alive without activity (seconds).
+    pub inactivity_ttl_secs: i64,
+    /// Maximum thread lifetime from creation, regardless of activity (seconds).
+    pub hard_cap_secs: i64,
+    /// Default Gaussian jitter applied to posted coordinates (metres).
+    pub default_sigma_m: f64,
+    /// Upper bound on client-requested sigma (metres).
+    pub max_sigma_m: f64,
+    /// Maximum character length for thread and comment content.
+    pub max_content_len: usize,
+    /// Maximum feed radius a client may request (kilometres).
+    pub max_radius_km: f64,
+}
+
+impl Config {
+    /// Read config from environment, falling back to protocol defaults for any missing key.
+    pub fn from_env() -> Self {
+        Self {
+            inactivity_ttl_secs: parse_env("INACTIVITY_TTL_SECS", 1800),
+            hard_cap_secs:        parse_env("HARD_CAP_SECS",        3600),
+            default_sigma_m:      parse_env("DEFAULT_SIGMA_M",       300.0),
+            max_sigma_m:          parse_env("MAX_SIGMA_M",           1000.0),
+            max_content_len:      parse_env("MAX_CONTENT_LEN",       300),
+            max_radius_km:        parse_env("MAX_RADIUS_KM",         10.0),
+        }
+    }
+}
+
+/// Parse a typed value from an env var, returning `default` if the var is
+/// absent or unparseable — so a bad value never silently becomes 0.
+fn parse_env<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod geo;
 mod models;
 mod routes;
@@ -8,6 +9,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use config::Config;
 use redis::aio::ConnectionManager;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -18,6 +20,7 @@ use tower_http::cors::CorsLayer;
 pub struct AppState {
     pub redis: ConnectionManager,
     pub clients: ws::ClientMap,
+    pub config: Config,
 }
 
 #[tokio::main]
@@ -33,6 +36,7 @@ async fn main() {
     let state = AppState {
         redis: manager,
         clients: Arc::new(RwLock::new(HashMap::new())),
+        config: Config::from_env(),
     };
 
     // Background task: every 30 seconds, scan the geo index for thread keys

--- a/backend/src/routes/comments.rs
+++ b/backend/src/routes/comments.rs
@@ -18,6 +18,11 @@ pub async fn post_comment(
     Path(thread_id): Path<String>,
     Json(body): Json<CreateComment>,
 ) -> Result<Json<Comment>, StatusCode> {
+    // Reject content that exceeds the configured character limit.
+    if body.content.len() > state.config.max_content_len {
+        return Err(StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -31,7 +36,7 @@ pub async fn post_comment(
     };
 
     let mut con = state.redis.clone();
-    let saved = add_comment(&mut con, &comment)
+    let saved = add_comment(&mut con, &comment, state.config.inactivity_ttl_secs, state.config.hard_cap_secs)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 

--- a/backend/src/routes/threads.rs
+++ b/backend/src/routes/threads.rs
@@ -14,23 +14,25 @@ use crate::{
     AppState,
 };
 
-const DEFAULT_NOISE_SIGMA_METERS: f64 = 300.0;
-const MAX_LIFETIME_SECS: i64 = 3600;
-
 pub async fn post_thread(
     State(state): State<AppState>,
     Json(body): Json<CreateThread>,
 ) -> Result<Json<Thread>, StatusCode> {
+    // Reject content that exceeds the configured character limit.
+    if body.content.len() > state.config.max_content_len {
+        return Err(StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs() as i64;
 
     // Use the client-supplied sigma if provided, otherwise fall back to the default.
-    // Clamped to 0–1000m so the client can't request absurd noise levels.
+    // Clamped to 0–max_sigma_m so the client can't request absurd noise levels.
     let sigma = body.noise_sigma
-        .unwrap_or(DEFAULT_NOISE_SIGMA_METERS)
-        .clamp(0.0, 1000.0);
+        .unwrap_or(state.config.default_sigma_m)
+        .clamp(0.0, state.config.max_sigma_m);
     let (fuzzed_lat, fuzzed_lng) = fuzz_coordinates(body.lat, body.lng, sigma);
 
     let thread = Thread {
@@ -39,13 +41,13 @@ pub async fn post_thread(
         lat: fuzzed_lat,
         lng: fuzzed_lng,
         created_at: now,
-        expires_at: now + MAX_LIFETIME_SECS,
+        expires_at: now + state.config.hard_cap_secs,
         last_activity: now,
         comment_count: 0,
     };
 
     let mut con = state.redis.clone();
-    save_thread(&mut con, &thread)
+    save_thread(&mut con, &thread, state.config.inactivity_ttl_secs)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -62,7 +64,7 @@ pub async fn get_feed_handler(
     State(state): State<AppState>,
     Query(params): Query<FeedQuery>,
 ) -> Result<Json<Vec<Thread>>, StatusCode> {
-    let radius = params.radius_km.clamp(1.0, 20.0);
+    let radius = params.radius_km.clamp(1.0, state.config.max_radius_km);
     let mut con = state.redis.clone();
 
     let threads = get_feed(&mut con, params.lat, params.lng, radius)

--- a/backend/src/store.rs
+++ b/backend/src/store.rs
@@ -3,8 +3,6 @@ use redis::{aio::ConnectionManager, AsyncCommands, Script};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const GEO_KEY: &str = "feed:geo";
-const INACTIVITY_TTL_SECS: i64 = 30 * 60; // 30 minutes
-const MAX_LIFETIME_SECS: i64 = 60 * 60;   // 1 hour hard cap
 
 fn now() -> i64 {
     SystemTime::now()
@@ -13,12 +11,14 @@ fn now() -> i64 {
         .as_secs() as i64
 }
 
+/// Store a new thread in Redis with the configured inactivity TTL.
 pub async fn save_thread(
     con: &mut ConnectionManager,
     thread: &Thread,
+    inactivity_ttl_secs: i64,
 ) -> redis::RedisResult<()> {
     let key = format!("thread:{}", thread.id);
-    let ttl = INACTIVITY_TTL_SECS;
+    let ttl = inactivity_ttl_secs;
 
     redis::pipe()
         .hset_multiple(
@@ -48,6 +48,8 @@ pub async fn save_thread(
 pub async fn add_comment(
     con: &mut ConnectionManager,
     comment: &Comment,
+    inactivity_ttl_secs: i64,
+    hard_cap_secs: i64,
 ) -> redis::RedisResult<bool> {
     let thread_key = format!("thread:{}", comment.thread_id);
     let comments_key = format!("thread:{}:comments", comment.thread_id);
@@ -91,8 +93,8 @@ pub async fn add_comment(
         .key(&comments_key)
         .arg(&comment_json)
         .arg(now())
-        .arg(INACTIVITY_TTL_SECS)
-        .arg(MAX_LIFETIME_SECS)
+        .arg(inactivity_ttl_secs)
+        .arg(hard_cap_secs)
         .invoke_async(con)
         .await?;
 

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -72,10 +72,11 @@ pub async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<crate::AppState>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(|socket| handle_socket(socket, state.clients))
+    let max_radius_km = state.config.max_radius_km;
+    ws.on_upgrade(move |socket| handle_socket(socket, state.clients, max_radius_km))
 }
 
-async fn handle_socket(socket: WebSocket, clients: ClientMap) {
+async fn handle_socket(socket: WebSocket, clients: ClientMap, max_radius_km: f64) {
     let id = Uuid::new_v4();
     let (tx, rx) = mpsc::unbounded_channel::<String>();
 
@@ -87,7 +88,7 @@ async fn handle_socket(socket: WebSocket, clients: ClientMap) {
     );
 
     let send_task = tokio::spawn(run_sender(rx, sink));
-    run_receiver(stream, &clients, id).await;
+    run_receiver(stream, &clients, id, max_radius_km).await;
 
     clients.write().await.remove(&id);
     send_task.abort();
@@ -108,12 +109,13 @@ async fn run_receiver(
     mut stream: SplitStream<WebSocket>,
     clients: &ClientMap,
     id: Uuid,
+    max_radius_km: f64,
 ) {
     while let Some(result) = stream.next().await {
         let Ok(msg) = result else { break };
         if let Message::Text(text) = msg {
             if let Ok(update) = serde_json::from_str::<LocationUpdate>(&text) {
-                let radius = update.radius_km.clamp(1.0, 10.0);
+                let radius = update.radius_km.clamp(1.0, max_radius_km);
                 if let Some(client) = clients.write().await.get_mut(&id) {
                     client.lat = update.lat;
                     client.lng = update.lng;


### PR DESCRIPTION
## Summary
- New `config.rs` — `Config` struct with all six qhlv protocol parameters (`INACTIVITY_TTL_SECS`, `HARD_CAP_SECS`, `DEFAULT_SIGMA_M`, `MAX_SIGMA_M`, `MAX_CONTENT_LEN`, `MAX_RADIUS_KM`), read from env vars at startup with safe defaults
- `Config` added to `AppState` and threaded to every call site that previously used scattered hardcoded consts
- Backend now enforces `MAX_CONTENT_LEN` on both threads and comments (was frontend-only before)
- Any qhlv node operator can now tune the protocol's behaviour without touching source code

## Test plan
- [ ] Build passes (`cargo build`)
- [ ] Server starts and behaves identically with no env vars set (all defaults preserved)
- [ ] Setting e.g. `MAX_CONTENT_LEN=10` rejects long posts with 422