### PR TITLE
Polish /como: blog-aligned typography and aesthetics

### DIFF
--- a/.claude/commands/new-page.md
+++ b/.claude/commands/new-page.md
@@ -1,0 +1,152 @@
+# New Page — hlv Style
+
+Create a new SvelteKit page at `frontend/src/routes/$ARGUMENTS/+page.svelte` that follows the hlv design system.
+
+## What to do
+
+1. Create the route directory and `+page.svelte` file.
+2. Apply the full style template below — do not improvise colours, fonts, or nav structure.
+3. Fill in the page-specific content (sections, headings, body copy) based on what the user asked for.
+4. Add a sidebar link from `+page.svelte` (the main app) pointing to the new route, styled the same as the existing `— blog` and `— cómo funciona` links.
+
+## Style template
+
+Every hlv sub-page must use this exact shell. Replace the `<title>` and page content only — keep everything else as-is.
+
+```svelte
+<svelte:head>
+  <title>hlv: PAGE_NAME</title>
+</svelte:head>
+
+<div class="page">
+  <nav>
+    <div class="brand-group">
+      <a href="/" class="brand">hlv</a>
+      <span class="tagline">hablan los vecinos</span>
+    </div>
+    <span class="sep">/</span>
+    <span class="crumb">PAGE_NAME</span>
+  </nav>
+
+  <!-- page content goes here -->
+</div>
+
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;1,300&display=swap');
+
+  :global(html, body) {
+    margin: 0;
+    background: #0a0a0a;
+    color: #e0e0e0;
+    font-family: 'DM Mono', monospace;
+    font-size: 18px;
+    line-height: 1.7;
+  }
+
+  .page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 48px 24px 80px;
+  }
+
+  /* ── nav (matches blog) ── */
+  nav {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 56px;
+  }
+
+  .brand-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .brand {
+    font-size: 40px;
+    letter-spacing: 10px;
+    color: #fff;
+    text-decoration: none;
+    line-height: 1;
+  }
+
+  .brand:hover { color: #aaa; }
+
+  .tagline {
+    font-size: 11px;
+    color: #444;
+    letter-spacing: 1px;
+    text-transform: lowercase;
+  }
+
+  .sep {
+    font-size: 20px;
+    color: #333;
+  }
+
+  .crumb {
+    font-size: 14px;
+    color: #555;
+    letter-spacing: 2px;
+    text-transform: lowercase;
+  }
+
+  /* ── content ── */
+  h2 {
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: lowercase;
+    color: #9a7f28;   /* mustard — used for section labels */
+    margin: 0 0 16px;
+  }
+
+  p {
+    font-size: 17px;
+    color: #ccc;
+    line-height: 1.75;
+    margin: 0 0 28px;
+  }
+
+  section {
+    margin-bottom: 72px;
+  }
+
+  /* ── mobile ── */
+  @media (max-width: 640px) {
+    .page  { padding: 32px 16px 60px; }
+    .brand { font-size: 28px; letter-spacing: 8px; }
+    nav    { margin-bottom: 40px; }
+  }
+</style>
+```
+
+## Colour reference
+
+| Token | Value | Use |
+|---|---|---|
+| Background | `#0a0a0a` | `html, body` |
+| Body text | `#ccc` / `#e0e0e0` | paragraphs / global default |
+| Mustard | `#9a7f28` | section labels (`h2`), accents |
+| Dim | `#444` | tagline, dates, captions |
+| Muted | `#555` | breadcrumb, secondary labels |
+| Ghost | `#333` | separators |
+| White | `#fff` | brand mark |
+
+## Font sizes
+
+| Element | Size |
+|---|---|
+| Brand mark (`hlv`) | 40px / letter-spacing 10px |
+| Tagline | 11px |
+| Breadcrumb | 14px |
+| Section label (`h2`) | 14px |
+| Body text | 17px |
+| Caption / fine print | 11px |
+
+## Notes
+
+- SSR is disabled project-wide via `+layout.js` (`export const ssr = false`). No need to add this per-page.
+- If the page needs canvas animations, follow the pattern in `frontend/src/routes/como/+page.svelte`: shared RAF loop, `onMount`/`onDestroy` lifecycle, canvas `bind:this`.
+- `max-width` can be narrowed below 680px for content-heavy or animation-heavy pages (como uses 480px), but the nav, fonts, and colours must stay consistent.

--- a/frontend/src/routes/como/+page.svelte
+++ b/frontend/src/routes/como/+page.svelte
@@ -339,6 +339,25 @@
       ctx.strokeStyle = 'rgba(255,255,255,0.09)';
       ctx.strokeRect(b.x + 0.5, b.y + 0.5, b.w - 1, b.h - 1);
     }
+
+    // Diagonal road — an older pre-grid street cutting across the city from lower-left to upper-right
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(0, 158);
+    ctx.quadraticCurveTo(88, 112, 200, 58);
+    ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+    ctx.lineWidth = 5;
+    ctx.stroke();
+    ctx.restore();
+
+    // Tiny plaza — open square at the street crossing in the lower-left grid (x≈40, y≈134)
+    ctx.save();
+    ctx.fillStyle = 'rgba(255,255,255,0.07)';
+    ctx.fillRect(40, 134, 8, 10);
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+    ctx.lineWidth = 0.5;
+    ctx.strokeRect(40.5, 134.5, 7, 9);
+    ctx.restore();
   }
 
   function drawCombGrid(ctx, alpha) {
@@ -558,11 +577,14 @@
 </svelte:head>
 
 <div class="page">
-  <header>
-    <a href="/" class="back">hlv</a>
-    <span class="sep">·</span>
-    <span class="title">cómo funciona</span>
-  </header>
+  <nav>
+    <div class="brand-group">
+      <a href="/" class="brand">hlv</a>
+      <span class="tagline">hablan los vecinos</span>
+    </div>
+    <span class="sep">/</span>
+    <span class="crumb">cómo funciona</span>
+  </nav>
 
   <section>
     <h2>ajuste a la cuadrícula</h2>
@@ -576,7 +598,7 @@
         <canvas bind:this={snapCanvas} width={W} height={H}></canvas>
       </div>
     </div>
-    <p class="caption">blanco: posición real — morado: ajustado a la cuadrícula.</p>
+    <p class="caption">la posición real (blanco) se desplaza al cruce de cuadrícula más cercano y queda registrada como el punto morado — nunca exactamente donde estabas.</p>
   </section>
 
   <section>
@@ -596,8 +618,7 @@
       <input type="range" min="50" max="1000" step="50" bind:value={noiseSigma} />
       <span class="noise-value">{noiseSigma}m</span>
     </div>
-    <p class="slider-note">al mover el slider de precisión, el área posible del mensaje cambia.</p>
-    <p class="caption">morado: posición ajustada a la cuadrícula — amarillo: posición publicada.</p>
+    <p class="caption">el punto ajustado (morado) se dispersa aleatoriamente antes de publicarse — el punto amarillo es la posición que ve el servidor; el slider cambia el radio de dispersión posible.</p>
   </section>
 
   <section>
@@ -612,7 +633,7 @@
         <canvas bind:this={combCanvas} width={CW} height={CH}></canvas>
       </div>
     </div>
-    <p class="caption">blanco: posición real — morado: ajustada a la cuadrícula — amarillo: publicada.</p>
+    <p class="caption">posición real (blanco) → ajuste a la cuadrícula (morado) → ruido gaussiano (amarillo): lo que se almacena nunca coincide con dónde estabas.</p>
   </section>
 
   <section>
@@ -633,7 +654,7 @@
       <input type="range" min="1" max="10" step="1" bind:value={feedRadius} />
       <span class="noise-value">{feedRadius}km</span>
     </div>
-    <p class="caption">blanco: tu posición real (no almacenada) — amarillo: mensajes dentro del radio.</p>
+    <p class="caption">solo ves los mensajes dentro del radio (amarillo); tu posición real (blanco) se usa para el cálculo pero nunca se almacena en el servidor.</p>
   </section>
 </div>
 
@@ -642,8 +663,8 @@
 
   :global(body) {
     margin: 0;
-    background: #111;
-    color: #ccc;
+    background: #0a0a0a;
+    color: #e0e0e0;
     font-family: 'DM Mono', monospace;
     font-size: 18px;
     line-height: 1.7;
@@ -655,33 +676,46 @@
     padding: 48px 24px 80px;
   }
 
-  header {
+  nav {
     display: flex;
     align-items: baseline;
-    gap: 8px;
+    gap: 10px;
     margin-bottom: 56px;
-    font-size: 14px;
   }
 
-  .back {
-    color: #fff;
-    text-decoration: none;
+  .brand-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .brand {
     font-size: 40px;
     letter-spacing: 10px;
+    color: #fff;
+    text-decoration: none;
     line-height: 1;
   }
 
-  .back:hover { color: #aaa; }
+  .brand:hover { color: #aaa; }
+
+  .tagline {
+    font-size: 11px;
+    color: #444;
+    letter-spacing: 1px;
+    text-transform: lowercase;
+  }
 
   .sep {
     font-size: 20px;
     color: #333;
   }
 
-  .title {
+  .crumb {
     font-size: 14px;
     color: #555;
     letter-spacing: 2px;
+    text-transform: lowercase;
   }
 
   section {
@@ -693,12 +727,12 @@
     font-weight: 400;
     letter-spacing: 2px;
     text-transform: lowercase;
-    color: #666;
+    color: #9a7f28;
     margin: 0 0 16px;
   }
 
   p {
-    color: #888;
+    color: #ccc;
     margin: 0 0 28px;
     font-size: 17px;
   }
@@ -710,11 +744,6 @@
 
   .glass-frame {
     display: inline-block;
-    border-radius: 14px;
-    border: 2px solid rgba(255, 255, 255, 0.14);
-    box-shadow:
-      inset 0 2px 0 rgba(255, 255, 255, 0.08),
-      inset 0 -2px 0 rgba(255, 255, 255, 0.03);
     overflow: hidden;
     line-height: 0;
   }
@@ -774,20 +803,18 @@
     cursor: pointer;
   }
 
-  .slider-note {
-    margin-top: 10px;
-    font-size: 11px;
-    color: #555;
-    text-align: center;
-    margin-bottom: 0;
-    font-style: italic;
-  }
-
   .caption {
     margin-top: 14px;
-    font-size: 11px;
-    color: #444;
+    font-size: 12px;
+    color: #888;
     margin-bottom: 0;
     text-align: center;
+    line-height: 1.6;
+  }
+
+  @media (max-width: 640px) {
+    .page { padding: 32px 16px 60px; }
+    .brand { font-size: 28px; letter-spacing: 8px; }
+    nav { margin-bottom: 40px; }
   }
 </style>

--- a/frontend/src/routes/como/+page.svelte
+++ b/frontend/src/routes/como/+page.svelte
@@ -645,7 +645,7 @@
     background: #111;
     color: #ccc;
     font-family: 'DM Mono', monospace;
-    font-size: 14px;
+    font-size: 18px;
     line-height: 1.7;
   }
 
@@ -660,23 +660,28 @@
     align-items: baseline;
     gap: 8px;
     margin-bottom: 56px;
-    font-size: 13px;
+    font-size: 14px;
   }
 
   .back {
     color: #fff;
     text-decoration: none;
-    font-size: 20px;
-    letter-spacing: 6px;
+    font-size: 40px;
+    letter-spacing: 10px;
+    line-height: 1;
   }
 
   .back:hover { color: #aaa; }
 
-  .sep { color: #333; }
+  .sep {
+    font-size: 20px;
+    color: #333;
+  }
 
   .title {
+    font-size: 14px;
     color: #555;
-    letter-spacing: 1px;
+    letter-spacing: 2px;
   }
 
   section {
@@ -684,7 +689,7 @@
   }
 
   h2 {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 400;
     letter-spacing: 2px;
     text-transform: lowercase;
@@ -695,7 +700,7 @@
   p {
     color: #888;
     margin: 0 0 28px;
-    font-size: 13px;
+    font-size: 17px;
   }
 
   .canvas-wrap {


### PR DESCRIPTION
## Summary
- Match `/como` typography scale to the blog (18px base, 40px brand mark, mustard section labels)
- Align aesthetics with blog (`#0a0a0a` background, brighter body text, stacked brand-group nav with `/` separator and tagline)
- Consolidate annotations to one per animation, rewritten as single coherent sentences (`#888`, 12px)
- Remove animation frame entirely — animations sit directly on page background
- Add diagonal curved road and tiny plaza to the city map in the combined animation
- New `/new-page` slash command that scaffolds hlv pages with correct nav structure, palette, and typography

## Test plan
- [ ] Visit `/como` locally — fonts and colors match blog
- [ ] Confirm all four animations render and run without the frame
- [ ] Verify nav structure (brand + tagline + `/` + cómo funciona) matches blog pattern
- [ ] Mobile check: animations and annotations remain legible