### PR TITLE
UI polish: como typography, animation frames, fader sliders, breathing textarea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,4 @@ When adding new code or modifying existing code, both levels should be present w
 - `thread_expired` WebSocket event to remove dead threads from feed automatically
 - Error states in UI (failed post, network issues)
 - Production deployment
+- CI deploy: GitHub Actions workflow on push to `main` to build the frontend and run `wrangler pages deploy`, replacing the manual command. Needs a Cloudflare API token (scoped to Pages:Edit) added as a repo secret (`CLOUDFLARE_API_TOKEN`); account ID can be a second secret or inline.

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -375,8 +375,32 @@
   label strong { color: #e0e0e0; }
 
   input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
     width: 100%;
-    accent-color: #e0e0e0;
+    height: 1px;
+    background: #333;
+    outline: none;
+    border-radius: 1px;
+    cursor: pointer;
+  }
+
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 9px;
+    border-radius: 1px;
+    background: rgba(192, 64, 64, 0.7);
+    cursor: pointer;
+  }
+
+  input[type="range"]::-moz-range-thumb {
+    width: 18px;
+    height: 9px;
+    border: none;
+    border-radius: 1px;
+    background: rgba(192, 64, 64, 0.7);
     cursor: pointer;
   }
 
@@ -394,8 +418,9 @@
   }
 
   textarea {
-    background: #111;
-    border: 1px solid #222;
+    background: #181818;
+    border: none;
+    border-radius: 8px;
     color: #7a6218;
     padding: 10px;
     font-family: inherit;
@@ -404,9 +429,14 @@
     width: 100%;
     outline: none;
     line-height: 1.5;
+    animation: textarea-breathe 40s ease-in-out infinite;
   }
 
-  textarea:focus { border-color: #444; }
+  /* Slow, faint white "breath" — like the LED pulse but white and dimmer. */
+  @keyframes textarea-breathe {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
+    50%      { box-shadow: 0 0 24px 4px rgba(255, 255, 255, 0.12); }
+  }
   .compose textarea::placeholder { color: #564812; opacity: 1; font-family: 'DM Mono', monospace; font-size: 17px; font-style: italic; }
   .comment-compose textarea::placeholder { color: #564812; opacity: 0.6; font-size: 17px; font-style: italic; }
 

--- a/frontend/src/routes/como/+page.svelte
+++ b/frontend/src/routes/como/+page.svelte
@@ -671,7 +671,7 @@
   }
 
   .page {
-    max-width: 480px;
+    max-width: 680px;
     margin: 0 auto;
     padding: 48px 24px 80px;
   }
@@ -735,6 +735,7 @@
     color: #ccc;
     margin: 0 0 28px;
     font-size: 17px;
+    line-height: 1.75;
   }
 
   .canvas-wrap {
@@ -746,6 +747,8 @@
     display: inline-block;
     overflow: hidden;
     line-height: 0;
+    border: 1px solid rgba(224, 224, 224, 0.15);
+    border-radius: 8px;
   }
 
   canvas {
@@ -787,19 +790,19 @@
   input[type='range']::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.5);
+    width: 18px;
+    height: 9px;
+    border-radius: 1px;
+    background: rgba(192, 64, 64, 0.7);
     cursor: pointer;
   }
 
   input[type='range']::-moz-range-thumb {
-    width: 10px;
-    height: 10px;
+    width: 18px;
+    height: 9px;
     border: none;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.5);
+    border-radius: 1px;
+    background: rgba(192, 64, 64, 0.7);
     cursor: pointer;
   }
 


### PR DESCRIPTION
## Summary
- **`/como` paragraphs match blog**: container widened to 680px, body line-height bumped to 1.75 — paragraphs now read with the same flow as `/blog`
- **Animation frames**: each of the four canvases on `/como` gets a subtle 1px frame at 15% opacity with 8px rounded corners
- **Fader-style sliders**: horizontal 18×9 red rectangle thumbs (`#c04040` at 70% opacity, the lit-LED color) on both `/como` and the main page's radio + precisión sliders. Track styled to a thin 1px line for the audio-fader look.
- **Breathing textarea**: main page compose/reply boxes are now borderless with 8px rounded corners, slightly lighter `#181818` background, and a slow 40s white breath via `box-shadow` — same family as the message-expiry LED pulse, but white and much dimmer (peaks at 12% opacity, ~24px blur)
- **CLAUDE.md**: GitHub Actions auto-deploy added to the planned-features list

## Test plan
- [ ] `/como` paragraph wrapping matches `/blog` at desktop widths
- [ ] All four `/como` animation canvases show the rounded frame and continue running
- [ ] Slider thumbs are red horizontal rectangles on both `/como` and the main page; dragging still works
- [ ] Textarea breathes slowly — wait ~20s after page load to see the glow swell
- [ ] Mobile: nothing visually broken