### PR TITLE
Consistent browser tab titles

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -225,6 +225,11 @@
 
 <svelte:window on:keydown={handleGlobalKey} />
 
+<!-- Browser tab title for the home page: brand mark plus tagline, so a lone tab still reads as the app. -->
+<svelte:head>
+  <title>hlv — hablan los vecinos</title>
+</svelte:head>
+
 <div class="app">
   <!-- Sidebar / controls + compose -->
   <aside>

--- a/frontend/src/routes/blog/+page.svelte
+++ b/frontend/src/routes/blog/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <svelte:head>
-  <title>hlv: hablan los vecinos — blog</title>
+  <title>hlv/blog</title>
 </svelte:head>
 
 <div class="blog">

--- a/frontend/src/routes/como/+page.svelte
+++ b/frontend/src/routes/como/+page.svelte
@@ -739,7 +739,7 @@
 </script>
 
 <svelte:head>
-  <title>qhlv: cómo funciona</title>
+  <title>hlv/como</title>
 </svelte:head>
 
 <div class="page">


### PR DESCRIPTION
## What

Make browser tab titles consistent across the three pages.

| Route | Before | After |
|---|---|---|
| `/` | *(none — browser showed the raw URL)* | `hlv — hablan los vecinos` |
| `/blog` | `hlv: hablan los vecinos — blog` | `hlv/blog` |
| `/como` | `qhlv: cómo funciona` | `hlv/como` |

## Why

The home page had no `<title>`, so a tab on `hablan.org` just showed the URL. The other two were inconsistent in style. New scheme: brand mark + tagline on home (so a lone tab still reads as the app), slash-style for subpages — scales cleanly to future pages.