### PR TITLE
Blog + /como copy: accuracy fixes and softer wording

### DIFF
--- a/frontend/src/lib/posts.js
+++ b/frontend/src/lib/posts.js
@@ -8,8 +8,8 @@ export const posts = [
     body: [
       'hlv es mensajería anónima, efímera y basada en ubicación.',
       'lo abres, publicas un mensaje, y ves lo que dice la gente cerca. sin cuentas, sin nombres de usuario, sin historial. los hilos mueren si nadie les responde.',
-      'la idea: un espacio público para conversación local que desaparece. más una pizarra que una red social.',
-      'la ubicación se difumina antes de guardarse — hlv sabe que estás en el barrio, no en qué edificio.'
+      'la idea: un espacio público para conversación local que desaparece. funciona más como una pizarra colaborativa que como una red social.',
+      'la ubicación se difumina antes de guardarse — hlv sabe que estás en el barrio, no en cuál casa.'
     ]
   },
   {
@@ -18,7 +18,7 @@ export const posts = [
     date: '2026-04-21',
     body: [
       'abre la página. permite el acceso a la ubicación cuando se solicite — así es como hlv sabe qué hay cerca.',
-      'usa el control de radio para ajustar qué tan lejos quieres ver mensajes. 1km es tu manzana, 20km cubre la mayor parte de una ciudad.',
+      'usa el control de radio para ajustar qué tan lejos quieres ver mensajes. 1km es tu manzana, 10km cubre buena parte de una ciudad.',
       'el control de precisión determina con qué exactitud se comparte tu ubicación. menos precisión = más privacidad, pero tus mensajes aparecen más lejos de donde estás.',
       'escribe algo en el área de texto y publícalo. cualquier persona dentro de tu radio lo verá en tiempo real.',
       'toca un hilo para leer respuestas y añadir la tuya. los hilos sin respuesta caducan a los 30 minutos. los hilos con actividad duran hasta una hora.',

--- a/frontend/src/routes/como/+page.svelte
+++ b/frontend/src/routes/como/+page.svelte
@@ -770,9 +770,10 @@
   <section>
     <h2>ruido gaussiano</h2>
     <p>
-      después del ajuste, se añade un desplazamiento aleatorio con
-      distribución normal — sigma ~300m por defecto. cada mensaje
-      publicado desde el mismo lugar llega a una posición diferente.
+      después del ajuste, se añade un desplazamiento aleatorio
+      (distribución normal — sigma ~300m por defecto, para los
+      interesados). cada mensaje publicado desde el mismo lugar
+      llega a una posición diferente.
     </p>
     <div class="canvas-wrap">
       <div class="glass-frame">


### PR DESCRIPTION
## Changes

**Blog (`posts.js`)**
- Radius example `20km` → `10km` to match the real cap (`MAX_RADIUS_KM: 10.0`, slider `max=10`).
- Reworded the "¿qué es hlv?" idea + location lines (pizarra colaborativa; "no en cuál casa").

**/como**
- Made the gaussian-noise sigma detail parenthetical and added "para los interesados" so general viewers can skim past the technical bit.

All copy-only; no logic changes.