### PR TITLE
Fix Android radius slider value not sticking

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -447,6 +447,11 @@
     outline: none;
     border-radius: 1px;
     cursor: pointer;
+    /* On touch devices (notably Android Chrome) the sliders sit inside a
+       scrollable sidebar. Without this, the browser treats a drag as a
+       scroll: the thumb moves visually but its value never sticks.
+       `touch-action: none` dedicates the drag gesture to the slider. */
+    touch-action: none;
   }
 
   input[type="range"]::-webkit-slider-thumb {


### PR DESCRIPTION
## Problem
On Android Chrome, dragging the radius (and precision) slider moves the thumb visually but the value never updates — the slider 'doesn't stick'.

## Cause
The sliders sit inside `aside { overflow-y: auto }`. With no `touch-action` on the range inputs, Android Chrome arbitrates the drag as a panel scroll rather than a slider drag, so the value never commits.

## Fix
`touch-action: none` on `input[type=range]`, dedicating the drag gesture to the slider. Desktop/mouse behavior unaffected.

## Verification
CSS-only; could not reproduce locally (Android-specific). Needs a check on a real Android device after deploy.